### PR TITLE
added optional checks for specific element or request on target page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "export-service",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "export service for PDF and PNG leveraging chrome headless",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,10 @@ function info (req: Request, res: Response) {
           url: 'string',
           options: 'Look at https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF',
           evalParams: {
-            delay: 'Number. Optional. Delay in milliseconds between loading page and making PDF file'
+            requiredUrl: 'String. Optional. Service will wait until specified endpoint not returns result to target page(1nd in queue, after document.load event)',
+            expectedElementId: 'String. Optional. Service will wait until element with specified id appears on target page(after requiredUrl check)',
+            delay: 'Number. Optional. Delay in milliseconds between loading page and making PDF file(after all checks)',
+            maxWaitingTime: 'Number. Optional. Specifies max delay(milliseconds), after which "expectedElementId" and "requiredUrl" related checks will be interrupted'
           }
         },
         response: {

--- a/src/support/EvaluationParameters.ts
+++ b/src/support/EvaluationParameters.ts
@@ -1,3 +1,6 @@
 export interface EvaluationParameters {
   delay?: number;
+  expectedElementId?: string;
+  maxWaitingTime?: number;
+  requiredUrl?: string;
 }

--- a/src/support/constants.ts
+++ b/src/support/constants.ts
@@ -25,3 +25,6 @@ export const INSTANCES_START_PORT = 9222;
 
 // quantity of attempts, which will be used for receiving image from one specific url
 export const ATTEMPTS_FOR_URL = 3;
+
+// delay in milliseconds between checks of a target page for required element
+export const DELAY_PER_CHECK = 200;


### PR DESCRIPTION
Added optional checks which can be specified via api:
Check if request to specified url(from target page) has been sent and responded
Check if on target page exists DOM element whit specified id

All of those checks will be interrupted force if specified time was been expired(protection of endless delay)